### PR TITLE
Ruleset: CardExpander: buttons and relevant UI changes

### DIFF
--- a/Source/Hurl.Library/Models/Ruleset.cs
+++ b/Source/Hurl.Library/Models/Ruleset.cs
@@ -6,9 +6,9 @@ namespace Hurl.Library.Models;
 
 public class Ruleset
 {
-    public string Name { get; set; }
-
     public List<string> Rules { get; set; }
+
+    public string RuleName { get; set; }
 
     public string BrowserName { get; set; }
 

--- a/Source/Hurl.Library/Models/Ruleset.cs
+++ b/Source/Hurl.Library/Models/Ruleset.cs
@@ -8,14 +8,13 @@ public class Ruleset
 {
     public List<string> Rules { get; set; }
 
-    public string RuleName { get; set; }
+    public string RulesetName { get; set; }
 
     public string BrowserName { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int? AltLaunchIndex { get; set; }
 }
-
 
 public enum RuleMode
 {
@@ -24,7 +23,6 @@ public enum RuleMode
     Regex,
     Glob
 }
-
 
 public class Rule
 {

--- a/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml
+++ b/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml
@@ -6,63 +6,65 @@
     xmlns:local="clr-namespace:Hurl.RulesetManager.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    d:DesignHeight="450"
-    d:DesignWidth="800"
     mc:Ignorable="d">
-    <ui:CardExpander x:Name="_CardExpander" Margin="0,2">
-        <StackPanel>
-            <Grid Margin="0,0,0,8">
+
+    <ui:CardExpander x:Name="_CardExpander" Margin="0,0,0,12">
+        <ui:CardExpander.Header>
+            <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-
-                <ui:Button
+                <!--  This content should really be set via a {Binding ruleset.RuleName}  -->
+                <TextBlock
+                    x:Name="Header_RuleName"
+                    Grid.Column="0"
                     Margin="0,0,8,0"
-                    Padding="12,7"
-                    Click="EditButton_Click"
-                    Icon="{ui:SymbolIcon Edit16}">
-                    Edit
-                </ui:Button>
-
-                <StackPanel
+                    VerticalAlignment="Center"
+                    FontWeight="SemiBold"
+                    TextTrimming="CharacterEllipsis"
+                    TextWrapping="NoWrap"
+                    ToolTip="{Binding ruleset.RuleName}" />
+                <!--  This content should really be set via a {Binding ruleset.Browser}  -->
+                <!--  Suggestion: use icon  -->
+                <TextBlock
+                    x:Name="Header_RuleBrowser"
                     Grid.Column="1"
-                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    TextWrapping="NoWrap" />
+                <StackPanel
+                    Grid.Column="2"
+                    Margin="8,0"
                     Orientation="Horizontal">
                     <ui:Button
                         Margin="0,0,8,0"
-                        Padding="12,8"
+                        Click="EditButton_Click"
+                        Icon="{ui:SymbolIcon Edit16}" />
+                    <ui:Button
+                        Margin="0,0,8,0"
                         Click="UpButton_Click"
                         Icon="{ui:SymbolIcon ArrowUp16}" />
                     <ui:Button
                         Margin="0,0,8,0"
-                        Padding="12,8"
                         Click="DownButton_Click"
                         Icon="{ui:SymbolIcon ArrowDown16}" />
                     <ui:Button
-                        Padding="12,8"
                         Click="DeleteButton_Click"
-                        Foreground="Red"
+                        Foreground="{ui:ThemeResource SystemFillColorCriticalBrush}"
                         Icon="{ui:SymbolIcon Delete16}" />
                 </StackPanel>
             </Grid>
+        </ui:CardExpander.Header>
 
-            <StackPanel>
-                <TextBlock
-                    Margin="0,0,0,8"
-                    FontSize="14"
-                    Text="{Binding Rules.Count, StringFormat={}{0} Rules Found}" />
-                <ItemsControl ItemsSource="{Binding Rules}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <ui:Card Padding="8">
-                                <TextBlock Text="{Binding}" />
-                            </ui:Card>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-        </StackPanel>
+        <ItemsControl ItemsSource="{Binding Rules}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <ui:Card Padding="8">
+                        <TextBlock Text="{Binding}" />
+                    </ui:Card>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </ui:CardExpander>
 </UserControl>

--- a/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml.cs
+++ b/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml.cs
@@ -20,7 +20,7 @@ public partial class RulesetAccordion : UserControl
         DataContext = ruleset;
 
         //This content should really be set via a Binding
-        Header_RuleName.Text = $"{ruleset.RuleName}";
+        Header_RuleName.Text = $"{ruleset.RulesetName}";
         Header_RuleBrowser.Text = $"{ruleset.BrowserName}";
     }
 

--- a/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml.cs
+++ b/Source/Hurl.RulesetManager/Controls/RulesetAccordion.xaml.cs
@@ -19,7 +19,9 @@ public partial class RulesetAccordion : UserControl
 
         DataContext = ruleset;
 
-        _CardExpander.Header = $"{ruleset.Name} ({ruleset.BrowserName})";
+        //This content should really be set via a Binding
+        Header_RuleName.Text = $"{ruleset.RuleName}";
+        Header_RuleBrowser.Text = $"{ruleset.BrowserName}";
     }
 
     private void EditButton_Click(object sender, RoutedEventArgs e)

--- a/Source/Hurl.RulesetManager/ViewModels/EditRulesetViewModel.cs
+++ b/Source/Hurl.RulesetManager/ViewModels/EditRulesetViewModel.cs
@@ -18,7 +18,7 @@ public class EditRulesetViewModel
         Browsers = SettingsState.GetBrowsers()
             .Select(x => x.Name)
             .ToList();
-        Name = set?.RuleName;
+        Name = set?.RulesetName;
         Rules = set?.Rules?
                     .Select(x => new Rule(x))
                     .ToList() ?? new List<Rule>();
@@ -75,7 +75,7 @@ public class EditRulesetViewModel
     {
         return new()
         {
-            RuleName = Name,
+            RulesetName = Name,
             BrowserName = Browsers[SelectedBrowser],
             Rules = Rules.Select(x => x.ToString())
                          .ToList(),

--- a/Source/Hurl.RulesetManager/ViewModels/EditRulesetViewModel.cs
+++ b/Source/Hurl.RulesetManager/ViewModels/EditRulesetViewModel.cs
@@ -18,7 +18,7 @@ public class EditRulesetViewModel
         Browsers = SettingsState.GetBrowsers()
             .Select(x => x.Name)
             .ToList();
-        Name = set?.Name;
+        Name = set?.RuleName;
         Rules = set?.Rules?
                     .Select(x => new Rule(x))
                     .ToList() ?? new List<Rule>();
@@ -75,7 +75,7 @@ public class EditRulesetViewModel
     {
         return new()
         {
-            Name = Name,
+            RuleName = Name,
             BrowserName = Browsers[SelectedBrowser],
             Rules = Rules.Select(x => x.ToString())
                          .ToList(),

--- a/Source/Hurl.RulesetManager/Windows/MainWindow.xaml
+++ b/Source/Hurl.RulesetManager/Windows/MainWindow.xaml
@@ -9,28 +9,24 @@
     Title="Ruleset Mananger - Hurl"
     Width="800"
     Height="600"
+    MinWidth="500"
     ExtendsContentIntoTitleBar="True"
     WindowBackdropType="Mica"
     WindowCornerPreference="Round"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
+    
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition Width="4*" MinWidth="420" />
-            <ColumnDefinition />
-        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <ui:TitleBar Title="Ruleset Manager - Hurl [BETA]" Grid.ColumnSpan="3" />
+        <ui:TitleBar Title="Ruleset Manager - Hurl [BETA]" />
 
         <Border
             Grid.Row="1"
-            Grid.Column="1"
             Margin="0,0,0,4"
             BorderBrush="#3377787E"
             BorderThickness="0,0,0,2">
@@ -63,13 +59,8 @@
             </StackPanel>
         </Border>
 
-
-        <ScrollViewer Grid.Row="2" Grid.Column="1">
-            <StackPanel
-                x:Name="_rulesetsList"
-                Margin="10,0"
-                VerticalAlignment="Stretch" />
+        <ScrollViewer Grid.Row="2">
+            <StackPanel x:Name="_rulesetsList" Margin="16,0" />
         </ScrollViewer>
-
     </Grid>
 </ui:FluentWindow>

--- a/Source/Hurl.RulesetManager/Windows/RuleTestingWindow.xaml.cs
+++ b/Source/Hurl.RulesetManager/Windows/RuleTestingWindow.xaml.cs
@@ -58,7 +58,7 @@ public partial class RuleTestingWindow
 
         if (matchingRuleset != null)
         {
-            PresentOutput($"Ruleset Match: {matchingRuleset.BrowserName}\nRuleset Name: {matchingRuleset?.Name}", Brushes.Green);
+            PresentOutput($"Ruleset Match: {matchingRuleset.BrowserName}\nRuleset RuleName: {matchingRuleset?.RuleName}", Brushes.Green);
         }
         else
         {

--- a/Source/Hurl.RulesetManager/Windows/RuleTestingWindow.xaml.cs
+++ b/Source/Hurl.RulesetManager/Windows/RuleTestingWindow.xaml.cs
@@ -58,11 +58,11 @@ public partial class RuleTestingWindow
 
         if (matchingRuleset != null)
         {
-            PresentOutput($"Ruleset Match: {matchingRuleset.BrowserName}\nRuleset RuleName: {matchingRuleset?.RuleName}", Brushes.Green);
+            PresentOutput($"Ruleset match: {matchingRuleset.BrowserName}\nRuleset name: {matchingRuleset?.RulesetName}", Brushes.Green);
         }
         else
         {
-            PresentOutput("No Ruleset Match", Brushes.Red);
+            PresentOutput("No Ruleset match", Brushes.Red);
         }
     }
 


### PR DESCRIPTION
Issue: #113

- moved buttons to Expander Header
- split text controls
- use `ruleset.RuleName` to be specific
- removed the Grid Columns to better use width

![image](https://github.com/U-C-S/Hurl/assets/65828559/8f9d78d0-e468-463a-96aa-4b47b4c4d490)