### PR TITLE
fix: No longer ignore LaunchArgs in AutoRulesCheck

### DIFF
--- a/Source/Hurl.BrowserSelector/Helpers/AutoRulesCheck.cs
+++ b/Source/Hurl.BrowserSelector/Helpers/AutoRulesCheck.cs
@@ -29,7 +29,7 @@ namespace Hurl.BrowserSelector.Helpers
                     {
                         if (RuleMatch.CheckMultiple(link, rules.Rules))
                         {
-                            string Args = string.IsNullOrEmpty(x.LaunchArgs) ? link + " " + x.LaunchArgs : link;
+                            string Args = string.IsNullOrEmpty(x.LaunchArgs) ? link : link + " " + x.LaunchArgs;
                             Process.Start(x.ExePath, Args);
 
                             return true;


### PR DESCRIPTION
Fixes #117 