### PR TITLE
Explicitly set dotnet SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.300",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Assemblies built with the build script were throwing exceptions for me on launch due to the .NET SDK version 9.0.100-preview.7 being installed. The root cause is an issue with this preview SDK version: https://github.com/dotnet/wpf/issues/9582. Since dotnet CLI uses preview SDKs by default while Visual Studio doesn't, this was leading to confusing behavior where VS-built assemblies worked, but script-built ones didn't. This solves the issue by explicitly setting the SDK version.