### PR TITLE
Fix hidden browsers showing up in Select window

### DIFF
--- a/Source/Hurl.BrowserSelector/Controls/BrowserButton.xaml.cs
+++ b/Source/Hurl.BrowserSelector/Controls/BrowserButton.xaml.cs
@@ -13,11 +13,8 @@ namespace Hurl.BrowserSelector.Controls
     {
         public BrowserButton(Browser browser)
         {
-            if (browser.Hidden == false)
-            {
-                InitializeComponent();
-                DataContext = browser;
-            }
+            InitializeComponent();
+            DataContext = browser;
         }
 
         private void BrowserButton_Click(object sender, RoutedEventArgs e)

--- a/Source/Hurl.BrowserSelector/Controls/BrowserButton.xaml.cs
+++ b/Source/Hurl.BrowserSelector/Controls/BrowserButton.xaml.cs
@@ -13,8 +13,11 @@ namespace Hurl.BrowserSelector.Controls
     {
         public BrowserButton(Browser browser)
         {
-            InitializeComponent();
-            DataContext = browser;
+            if (browser.Hidden == false)
+            {
+                InitializeComponent();
+                DataContext = browser;
+            }
         }
 
         private void BrowserButton_Click(object sender, RoutedEventArgs e)

--- a/Source/Hurl.BrowserSelector/Windows/MainWindow.xaml.cs
+++ b/Source/Hurl.BrowserSelector/Windows/MainWindow.xaml.cs
@@ -74,8 +74,11 @@ public partial class MainWindow : FluentWindow
     {
         foreach (var browser in Settings.Browsers)
         {
-            var browserBtn = new BrowserButton(browser);
-            BrowsersList.Children.Add(browserBtn);
+            if (!browser.Hidden)
+            {
+                var browserBtn = new BrowserButton(browser);
+                BrowsersList.Children.Add(browserBtn);
+            }
         }
     }
 


### PR DESCRIPTION
So, in Hurl v0.9.0, there's an issue where the if you set a browser as hidden, it would still shows up.

![image](https://github.com/user-attachments/assets/9f2324ac-7757-4ba0-9d7b-fd069e20dfb9)

So this PR, fixes the issue by not including the hidden browsers in the browser selector screen. Thanks.