### PR TITLE
Support multiple displays when opening window under the cursor

### DIFF
--- a/Source/Hurl.BrowserSelector/Helpers/CursorPosition.cs
+++ b/Source/Hurl.BrowserSelector/Helpers/CursorPosition.cs
@@ -1,43 +1,35 @@
-﻿using System.Runtime.InteropServices;
-using System.Windows;
+﻿using System.Drawing;
+using System.Windows.Forms;
+using System.Diagnostics;
 
 namespace Hurl.BrowserSelector.Helpers
 {
-    public static partial class CursorPosition
+    public static class CursorPosition
     {
-        [LibraryImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool GetCursorPos(ref Win32Point pt);
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct Win32Point
-        {
-            public int X;
-            public int Y;
-        };
-        public static Point Get()
-        {
-            var w32Mouse = new Win32Point();
-            GetCursorPos(ref w32Mouse);
-
-            return new Point(w32Mouse.X, w32Mouse.Y);
-        }
-
         public static Point LimitCursorWithin(int width, int height)
         {
-            var Cursor = Get();
-            var finalPoint = new Point(Cursor.X, Cursor.Y);
-            double screenHeight = SystemParameters.FullPrimaryScreenHeight;
-            double screenWidth = SystemParameters.FullPrimaryScreenWidth;
+            var cursor = Cursor.Position;
+            var screen = Screen.GetWorkingArea(cursor);
+            var finalPoint = new Point(cursor.X - width / 2, cursor.Y - height / 2);
 
-            if (Cursor.X + width > screenWidth)
+            if (cursor.X + width / 2 > screen.Right)
             {
-                finalPoint.X = screenWidth - width;
+                finalPoint.X = screen.Right - width;
             }
-            if (Cursor.Y + height > screenHeight)
+            if (cursor.X - width / 2 < screen.Left)
             {
-                finalPoint.Y = screenHeight - height;
+                finalPoint.X = screen.Left;
             }
+            if (cursor.Y + height / 2 > screen.Bottom)
+            {
+                finalPoint.Y = screen.Bottom - height;
+            }
+            if (cursor.Y - height / 2 < screen.Top)
+            {
+                finalPoint.Y = screen.Top;
+            }
+
+            Debug.WriteLine($"{finalPoint.X}�{finalPoint.Y} with screen resolution: {screen.Width}�{screen.Height}");
 
             return finalPoint;
         }

--- a/Source/Hurl.BrowserSelector/Hurl.BrowserSelector.csproj
+++ b/Source/Hurl.BrowserSelector/Hurl.BrowserSelector.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
 		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
 		<UseWPF>true</UseWPF>
+		<UseWindowsForms>true</UseWindowsForms>
 		<Nullable>enable</Nullable>
 		<AssemblyName>Hurl</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Source/Hurl.BrowserSelector/Windows/MainWindow.xaml.cs
+++ b/Source/Hurl.BrowserSelector/Windows/MainWindow.xaml.cs
@@ -197,15 +197,12 @@ public partial class MainWindow : FluentWindow
         {
             if (appSettings?.LaunchUnderMouse == true)
             {
-                var transform = PresentationSource.FromVisual(this)?.CompositionTarget?.TransformFromDevice;
-                if (transform is Matrix t)
-                {
-                    var mouse = t.Transform(CursorPosition.LimitCursorWithin((int)Width, (int)Height));
-                    Left = mouse.X;
-                    Top = mouse.Y;
-
-                    Debug.WriteLine($"{Left}�{Top} with screen resolution: {SystemParameters.FullPrimaryScreenWidth}�{SystemParameters.FullPrimaryScreenHeight}");
-                }
+                var dpiScale = VisualTreeHelper.GetDpi(this);
+                var width = (appSettings?.WindowSize[0] ?? 420) * dpiScale.DpiScaleX;
+                var height = (appSettings?.WindowSize[1] ?? 210) * dpiScale.DpiScaleY;
+                var position = CursorPosition.LimitCursorWithin((int)width, (int)height);
+                Left = position.X / dpiScale.DpiScaleX;
+                Top = position.Y / dpiScale.DpiScaleY;
             }
         }
         catch (Exception) { }


### PR DESCRIPTION
This should fix #95, works well on my setup with three screens.

Some things to note:
- I've added Windows Forms to the project in order to be able to use methods to get the cursor position and display bounds. There's probably a way to do it using native API calls, but this way results in cleaner code and doesn't seem to add to the build size.
- I'm positioning the window so that the cursor is in the center rather than the top left corner. Just a matter of taste, but feels slightly more convenient to me.
- I'm using VisualTreeHelper.GetDpi instead of matrices to convert coordinates which seems simpler, especially when converting in both directions.
- I was running into a problem with the width and height values of the window being too small while it was minimised, resulting in wrong calculations when near the screen edge. In the end, I've opted for using the values stored in the settings instead.
- Not sure if the try...catch block is still needed, but I've left it for now.

Let me know if this sounds fine!