### PR TITLE
fix: align settings schema and docs with current code

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -42,7 +42,7 @@ The following snippet shows the default options:
     "NoWhiteBorder": false,
     "BackgroundType": "mica",
     "RuleMatching": false,
-    "WindowSize": [460,210]
+    "WindowSize": [460,230]
 }
 ```
 

--- a/Utils/UserSettings.schema.json
+++ b/Utils/UserSettings.schema.json
@@ -69,8 +69,8 @@
         },
         "BackgroundType": {
           "type": "string",
-          "description": "The type of background to use for the browser window. mica or acrylic.",
-          "enum": ["mica", "acrylic"]
+          "description": "The type of background to use for the browser window. mica, acrylic, or solid.",
+          "enum": ["mica", "acrylic", "solid"]
         },
         "WindowSize": {
           "type": "array",
@@ -96,8 +96,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "The URL pattern prefixed with s$, g$, r$ or d$, followed by the pattern to match. s$ = simple string, r$ = regex, d$ = domain.",
-              "pattern": "^(s\\$|r\\$|d\\$).*"
+              "description": "The URL pattern, optionally prefixed with s$, r$, or d$. The prefix selects how the pattern is matched; an unprefixed value is treated as a simple string. s$ = simple string, r$ = regex, d$ = domain.",
+              "pattern": "^(s\\$|r\\$|d\\$)?.+$"
             }
           },
           "BrowserName": {


### PR DESCRIPTION
Refs #163.

Three drift items the issue + thread converged on. Each is a one-line edit; all sit inside `Utils/UserSettings.schema.json` and `Docs/README.md`.

## 1. BackgroundType enum is missing `solid`

The Settings UI emits `solid` when the third option is selected:

```cs
// Source/Hurl.Settings/ViewModels/SettingsViewModel.cs:76-80
AppSettings.BackgroundType = value switch
{
    0 => "mica",
    1 => "acrylic",
    _ => "solid"
};
```

The schema's enum is `["mica", "acrylic"]`, so a settings.json the app itself writes can fail schema validation. Added `solid`.

## 2. Rule pattern requires a prefix; docs say it shouldn't

Docs/README.md table:

| Rule Type | Format | Example |
|---|---|---|
| String | `s$__your_rule__` or `__your_rule__` | `https://github.com/U-C-S` |

But the current pattern requires one of the prefixes:

```diff
- "pattern": "^(s\\$|r\\$|d\\$).*"
+ "pattern": "^(s\\$|r\\$|d\\$)?.+$"
```

Per @Jay-o-Way's note in #163, optional prefix via `(...)?` is the cleanest expression of "any of these prefixes, or none."

The description string also still mentioned `g\$` even though the Glob rule type was removed in b55c694; replaced that line.

## 3. WindowSize default in docs is below MinHeight

Docs example shows `"WindowSize": [460,210]`. `MainWindow.xaml:13-14` sets `MinHeight="230"`, so 210 is below the WPF-enforced floor. Per @Jay-o-Way "I think the code is leading"; changed the docs example to `[460,230]`.

## What I didn't touch

- The separate concern about `solid` vs `none` between MainWindow.xaml.cs and the docs (`MainWindow.xaml.cs:42` checks `backtype == "none"`, the docs say `mica/acrylic/none`, but the UI emits `solid`). That's a code-vs-docs decision, not a schema one. Happy to follow up once the right answer is decided.