### PR TITLE
Support subdomain matching in Domain rule type

### DIFF
--- a/Docs/Features/RuleMatching.md
+++ b/Docs/Features/RuleMatching.md
@@ -7,7 +7,7 @@ They are text strings, which when configured can automatically open a browser fo
 ### Types of rules
 
 - `String`: This does simple text matching. Triggers if your URL matches exactly with this plain rule.
-- `Domain`: Simply the domain part of a URL, example: For the URL `https://github.com/u-c-s/hurl`, `github.com` is the domain. Probably the most useful rule type.
+- `Domain`: Simply the domain part of a URL, example: For the URL `https://github.com/u-c-s/hurl`, `github.com` is the domain. Probably the most useful rule type. By default it matches the host exactly, so `github.com` will not match `docs.github.com`. To also match subdomains, prefix the domain with `*.` — a rule of `*.github.com` matches `github.com` itself as well as any subdomain such as `docs.github.com`.
 - `Regex`: Uses Regular Expressions to do text matching. Use <https://regex101.com> with (.NET/C# flavor) to test your rules.
 
 > [!NOTE]
@@ -73,5 +73,5 @@ Note that when adding rules to _UserSettings.json_ directly, follow the below pa
 | Rule type | Format | Example |
 | --- | --- | --- |
 | String | `s$<YourRule>` or `<YourRule>` | `https://github.com/U-C-S` |
-| Domain | `d$<YourRule>` | `d$github.com` |
+| Domain | `d$<YourRule>` | `d$github.com` (exact) or `d$*.github.com` (with subdomains) |
 | Regex  | `r$<YourRule>` | `r$.*open\\.spotify\\.com.*` |

--- a/Source/Hurl.Library/RuleMatch.cs
+++ b/Source/Hurl.Library/RuleMatch.cs
@@ -44,10 +44,24 @@ public class RuleMatch
 
     public static bool DomainCheck(string link, string rule)
     {
-        var uri = new Uri(link);
+        if (!Uri.TryCreate(link, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
         var domain = uri.Host;
 
-        return domain.Equals(rule);
+        // A rule of the form "*.example.com" matches "example.com" itself
+        // as well as any of its subdomains (e.g. "docs.example.com").
+        if (rule.StartsWith("*.", StringComparison.Ordinal))
+        {
+            var baseDomain = rule[2..];
+
+            return domain.Equals(baseDomain, StringComparison.OrdinalIgnoreCase)
+                || domain.EndsWith("." + baseDomain, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return domain.Equals(rule, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool RegexCheck(string link, string rule)


### PR DESCRIPTION
## Summary

This adds optional subdomain matching to the `Domain` rule type. Writing a rule as `*.example.com` now matches both the apex host `example.com` and any subdomain such as `docs.example.com`, while a plain `example.com` rule keeps its existing exact-match behavior untouched.

The whole change lives in `DomainCheck`. When the rule content begins with `*.`, the prefix is stripped and the host is considered a match if it equals the base domain or ends with a dot followed by the base domain. The dot boundary is what keeps `evilgithub.com` from matching `*.github.com`. Anything without the `*.` prefix falls through to the same exact comparison as before, so existing rulesets behave identically.

While in the method I also replaced `new Uri(link)` with `Uri.TryCreate` so malformed input returns false directly instead of leaning on the outer try/catch, and switched the host comparisons to be case-insensitive, which reflects how hostnames actually work.

## Why this matters

The `Domain` rule only ever matched the exact host, so a `d$github.com` rule would not route a link to `docs.github.com`. People reasonably expected a wildcard form to capture subdomains, and the documentation sample already showed a `*.google.com`-style rule, so the syntax was implied in user-facing material but not actually supported by the matcher. This closes that gap with the least-surprising interpretation and no schema or UI change, since the wildcard lives inside the existing rule string. See https://github.com/U-C-S/Hurl/issues/107.

## Testing

Since the repository has no unit-test project, I exercised `DomainCheck` in a standalone harness covering exact match preserved, `github.com` not leaking into `docs.github.com`, `*.github.com` matching both the apex and subdomains, the dot-boundary guard rejecting `evilgithub.com`, malformed input returning false without throwing, and case-insensitive matching for both forms. All cases passed. The library also builds cleanly with `dotnet build Source/Hurl.Library/Hurl.Library.csproj -c Release -p:EnableWindowsTargeting=true` (the targeting flag is only needed because this Windows project was built on a non-Windows host), with no new warnings.

Fixes #107.
