### PR TITLE
Add selector digit shortcuts

### DIFF
--- a/Source/Hurl.App/Controls/BrowserBarButton.xaml
+++ b/Source/Hurl.App/Controls/BrowserBarButton.xaml
@@ -19,6 +19,18 @@
             BorderBrush="#33FFFFFF"
             BorderThickness="1"
             CornerRadius="6" />
+        <Border
+            Margin="6"
+            Padding="6,2"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            Background="#A6000000"
+            CornerRadius="999"
+            Visibility="{x:Bind BrowserItem.ShortcutHintVisibility, Mode=OneWay}">
+            <TextBlock
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{x:Bind BrowserItem.ShortcutHintText, Mode=OneWay}" />
+        </Border>
         <Button
             x:Name="LaunchButton"
             Padding="4"

--- a/Source/Hurl.App/Controls/BrowserBarButton.xaml.cs
+++ b/Source/Hurl.App/Controls/BrowserBarButton.xaml.cs
@@ -89,6 +89,7 @@ public sealed partial class BrowserBarButton : UserControl
             new PropertyMetadata(null, OnLaunchCommandChanged));
 
     public event EventHandler<AlternateLaunchRequestedEventArgs>? AlternateLaunchRequested;
+
     #endregion
 
     #region AltLaunch Flyout

--- a/Source/Hurl.App/ViewModels/BrowserItemViewModel.cs
+++ b/Source/Hurl.App/ViewModels/BrowserItemViewModel.cs
@@ -1,7 +1,9 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Hurl.Library.Models;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using WinRT;
 
 namespace Hurl.App.ViewModels;
@@ -16,5 +18,22 @@ public partial class BrowserItemViewModel(Browser model) : ObservableObject
     public ObservableCollection<AlternateLaunch>? AlternateLaunches => Model.AlternateLaunches;
 
     [ObservableProperty]
+    public partial int? ShortcutIndex { get; set; }
+
+    public string ShortcutHintText => ShortcutIndex is int shortcutIndex && shortcutIndex >= 0 && shortcutIndex < 9
+        ? (shortcutIndex + 1).ToString(CultureInfo.InvariantCulture)
+        : string.Empty;
+
+    public Visibility ShortcutHintVisibility => string.IsNullOrEmpty(ShortcutHintText)
+        ? Visibility.Collapsed
+        : Visibility.Visible;
+
+    [ObservableProperty]
     public partial BitmapImage? Icon { get; set; }
+
+    partial void OnShortcutIndexChanged(int? value)
+    {
+        OnPropertyChanged(nameof(ShortcutHintText));
+        OnPropertyChanged(nameof(ShortcutHintVisibility));
+    }
 }

--- a/Source/Hurl.App/ViewModels/SelectorPageViewModel.cs
+++ b/Source/Hurl.App/ViewModels/SelectorPageViewModel.cs
@@ -40,13 +40,17 @@ public partial class SelectorPageViewModel : ObservableObject
     {
         Browsers.Clear();
 
+        int visibleBrowserIndex = 0;
+
         foreach (var browser in settings.Browsers.Where(b => !b.Hidden))
         {
             BrowserItemViewModel item = new(browser)
             {
-                Icon = await _iconLoader.LoadIconAsync(browser)
+                Icon = await _iconLoader.LoadIconAsync(browser),
+                ShortcutIndex = visibleBrowserIndex
             };
             Browsers.Add(item);
+            visibleBrowserIndex++;
         }
     }
 
@@ -56,15 +60,25 @@ public partial class SelectorPageViewModel : ObservableObject
     {
         get
         {
-            return launchBrowserCommand ??= new RelayCommand<BrowserItemViewModel>(LaunchBrowser);
+            return launchBrowserCommand ??= new RelayCommand<BrowserItemViewModel>(browserItem => _ = LaunchBrowser(browserItem));
         }
     }
 
-    private void LaunchBrowser(BrowserItemViewModel? browserItem)
+    public bool LaunchBrowserAtIndex(int zeroBasedIndex)
+    {
+        if (zeroBasedIndex < 0 || zeroBasedIndex >= Browsers.Count)
+        {
+            return false;
+        }
+
+        return LaunchBrowser(Browsers[zeroBasedIndex]);
+    }
+
+    private bool LaunchBrowser(BrowserItemViewModel? browserItem)
     {
         if (browserItem is null)
         {
-            return;
+            return false;
         }
 
         Browser browser = browserItem.Model;
@@ -73,10 +87,12 @@ public partial class SelectorPageViewModel : ObservableObject
         {
             UriLauncher.ResolveAutomatically(Url, browser, null);
             BrowserLaunched?.Invoke(this, EventArgs.Empty);
+            return true;
         }
         catch (Exception ex)
         {
             Debug.WriteLine(ex);
+            return false;
         }
     }
 }

--- a/Source/Hurl.App/Views/SelectorWindow.xaml
+++ b/Source/Hurl.App/Views/SelectorWindow.xaml
@@ -19,6 +19,24 @@
         KeyboardAcceleratorPlacementMode="Hidden"
         RowSpacing="8">
         <Grid.KeyboardAccelerators>
+            <KeyboardAccelerator Key="Number1" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number2" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number3" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number4" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number5" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number6" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number7" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number8" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="Number9" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad1" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad2" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad3" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad4" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad5" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad6" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad7" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad8" Invoked="BrowserDigitAccelerator_Invoked" />
+            <KeyboardAccelerator Key="NumberPad9" Invoked="BrowserDigitAccelerator_Invoked" />
             <KeyboardAccelerator Key="C" Invoked="CopyAccelerator_Invoked" />
             <KeyboardAccelerator
                 Key="E"
@@ -41,7 +59,7 @@
             <TextBlock
                 VerticalAlignment="Center"
                 Style="{StaticResource BodyTextBlockStyle}"
-                Text="Select a browser" />
+                Text="Select a browser (1-9)" />
             <DropDownButton Grid.Column="1">
                 <DropDownButton.Content>
                     <FontIcon FontSize="16" Glyph="&#xE700;" />

--- a/Source/Hurl.App/Views/SelectorWindow.xaml.cs
+++ b/Source/Hurl.App/Views/SelectorWindow.xaml.cs
@@ -11,6 +11,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.System;
 using WinRT;
 using WinUIEx;
 
@@ -251,9 +252,45 @@ public sealed partial class SelectorWindow : Window
         args.Handled = true;
     }
 
+    private void BrowserDigitAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (IsEditableInputFocused())
+        {
+            return;
+        }
+
+        int browserIndex = sender.Key switch
+        {
+            VirtualKey.Number1 => 0,
+            VirtualKey.Number2 => 1,
+            VirtualKey.Number3 => 2,
+            VirtualKey.Number4 => 3,
+            VirtualKey.Number5 => 4,
+            VirtualKey.Number6 => 5,
+            VirtualKey.Number7 => 6,
+            VirtualKey.Number8 => 7,
+            VirtualKey.Number9 => 8,
+            VirtualKey.NumberPad1 => 0,
+            VirtualKey.NumberPad2 => 1,
+            VirtualKey.NumberPad3 => 2,
+            VirtualKey.NumberPad4 => 3,
+            VirtualKey.NumberPad5 => 4,
+            VirtualKey.NumberPad6 => 5,
+            VirtualKey.NumberPad7 => 6,
+            VirtualKey.NumberPad8 => 7,
+            VirtualKey.NumberPad9 => 8,
+            _ => -1
+        };
+
+        if (browserIndex >= 0 && ViewModel.LaunchBrowserAtIndex(browserIndex))
+        {
+            args.Handled = true;
+        }
+    }
+
     private void CopyAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
-        if (IsTextBoxKeyAccelerator())
+        if (IsEditableInputFocused())
         {
             return;
         }
@@ -264,7 +301,7 @@ public sealed partial class SelectorWindow : Window
 
     private async void EditUrlAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
-        if (IsTextBoxKeyAccelerator())
+        if (IsEditableInputFocused())
         {
             return;
         }
@@ -275,7 +312,7 @@ public sealed partial class SelectorWindow : Window
 
     private void RulesAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
-        if (IsTextBoxKeyAccelerator())
+        if (IsEditableInputFocused())
         {
             return;
         }
@@ -285,7 +322,7 @@ public sealed partial class SelectorWindow : Window
         args.Handled = true;
     }
 
-    private bool IsTextBoxKeyAccelerator()
+    private bool IsEditableInputFocused()
     {
         var xamlRoot = (Content as FrameworkElement)?.XamlRoot;
         return xamlRoot is not null && FocusManager.GetFocusedElement(xamlRoot) is TextBox;


### PR DESCRIPTION
## Summary
- add popup keyboard shortcuts so visible browsers can be launched with 1-9
- add on-tile shortcut badges and reuse the existing launch path for click and keyboard selection
- address review findings by supporting numpad digits and moving badge state onto observable view-model properties

## Validation
- dotnet build .\\Source\\Hurl.App\\Hurl.App.csproj -c Debug -p:Platform=x64 -p:RuntimeIdentifier=win-x64 --no-restore

<img width="624" height="471" alt="image" src="https://github.com/user-attachments/assets/a05123de-065b-4b47-a088-2bde3982c279" />
